### PR TITLE
(MAINT) Add DSC repo to site menu

### DIFF
--- a/_site/hugo.yaml
+++ b/_site/hugo.yaml
@@ -11,10 +11,14 @@ menu:
       url:    https://learn.microsoft.com/powershell/dsc/overview?view=dsc-3.0
       pre:    <sl-icon name="bxl-microsoft" library="boxicons"></sl-icon>
       weight: 10
+    - name:   DSC Repository
+      url:    https://learn.microsoft.com/powershell/dsc/overview?view=dsc-3.0
+      pre:    <sl-icon name="bxl-github" library="boxicons"></sl-icon>
+      weight: 20
     - name:   Samples Source
       url:    https://github.com/PowerShell/DSC-Samples
       pre:    <sl-icon name="bxl-github" library="boxicons"></sl-icon>
-      weight: 20
+      weight: 30
 
 params:
   description: Sample implementations for Desired State Configuration v3.


### PR DESCRIPTION
# PR Summary

Adds the DSC repo link to the site menu.

## PR Context

The site menu should link to the DSC docs, the DSC repository, and to the samples repository.