### PR TITLE
(MAINT) Fix GitHub Pages deployment

### DIFF
--- a/.github/workflows/publish.site.yml
+++ b/.github/workflows/publish.site.yml
@@ -25,8 +25,10 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all history for .GitInfo and .Lastmod
       - name: Setup Pages
+        id:   pages
         uses: actions/configure-pages@v3
       - name: Setup Hugo
+        id:   hugo
         uses: peaceiris/actions-hugo@v2
         with:
           hugo-version: latest
@@ -65,7 +67,7 @@ jobs:
           HUGO_ENVIRONMENT: production
           HUGO_ENV: production
         run: |
-          Invoke-Build -Task BuildSite -SiteBaseUrl https://powershell.github.io/DSC-Samples/
+          Invoke-Build -Task BuildSite -SiteBaseUrl "${{ steps.pages.outputs.base_url }}/"
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
         with:


### PR DESCRIPTION
# PR Summary

This change updates the GHA for building and deploying the site to GitHub Pages to use the base url output of the pages setup step as the base url for the build process, instead of hard-coding the canonical URL.

Until the site goes public, the URL is non-standard and using the canonical URL breaks the styling and other functionality.

This change should be resilient, working even after the site deploys to the canonical URL.
## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://powershell.github.io/DSC-Samples/contributing/
[style]:   https://powershell.github.io/DSC-Samples/contributing/style-guide/
