### PR TITLE
(MAINT) Fix link to DSC repo in menu

### DIFF
--- a/.site/hugo.yaml
+++ b/.site/hugo.yaml
@@ -12,7 +12,7 @@ menu:
       pre:    <sl-icon name="bxl-microsoft" library="boxicons"></sl-icon>
       weight: 10
     - name:   DSC Repository
-      url:    https://learn.microsoft.com/powershell/dsc/overview?view=dsc-3.0
+      url:    https://github.com/PowerShell/DSC
       pre:    <sl-icon name="bxl-github" library="boxicons"></sl-icon>
       weight: 20
     - name:   Samples Source


### PR DESCRIPTION
# PR Summary

The link to the DSC repository in the site menu erroneously linked to the official documentation. This change fixes the link.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://powershell.github.io/DSC-Samples/contributing/
[style]:   https://powershell.github.io/DSC-Samples/contributing/style-guide/
