### PR TITLE
Update Code of Conduct and Security Policy

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -7,3 +7,4 @@ Resources:
 - [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/)
 - [Microsoft Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
 - Contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with questions or concerns
+- Employees can reach out at [aka.ms/opensource/moderation-support](https://aka.ms/opensource/moderation-support)

--- a/README.md
+++ b/README.md
@@ -12,19 +12,31 @@ For more information about DSC v3, see [the DSC v3 repository][00].
 
 This project welcomes contributions and suggestions. Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+the rights to use your contribution. For details, visit our [Contributor License Agreements][01].
 
 When you submit a pull request, a CLA bot will automatically determine whether you need to provide
 a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the
 instructions provided by the bot. You will only need to do this once across all repos using our
 CLA.
 
-This project has adopted the [Microsoft Open Source Code of Conduct][01]. For more information see
-the [Code of Conduct FAQ][02] or contact [opencode@microsoft.com][03] with any additional questions
-or comments.
-
-The [Contribution Guide][04] includes in-depth information and guidance for contributing to this
+The [Contribution Guide][02] includes in-depth information and guidance for contributing to this
 project.
+
+<!-- vale on -->
+
+## Code of Conduct
+
+<!-- vale off -->
+
+Please see our [Code of Conduct][03] before participating in this project.
+
+<!-- vale on -->
+
+## Security Policy
+
+<!-- vale off -->
+
+For any security issues, please see our [Security Policy][04].
 
 <!-- vale on -->
 
@@ -51,10 +63,10 @@ patents, or trademarks, whether by implication, estoppel or otherwise.
 <!-- vale on -->
 
 [00]: https://github.com/PowerShell/DSC/
-[01]: https://opensource.microsoft.com/codeofconduct/
-[02]: https://opensource.microsoft.com/codeofconduct/faq/
-[03]: mailto:opencode@microsoft.com
-[04]: https://powershell.github.io/DSC-Samples/contributing
+[01]: https://cla.opensource.microsoft.com
+[02]: https://powershell.github.io/DSC-Samples/contributing
+[03]: CODE_OF_CONDUCT.md
+[04]: SECURITY.md
 [05]: https://creativecommons.org/licenses/by/4.0/legalcode
 [06]: LICENSE
 [07]: https://opensource.org/licenses/MIT

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,20 +1,20 @@
-<!-- BEGIN MICROSOFT SECURITY.MD V0.0.8 BLOCK -->
+<!-- BEGIN MICROSOFT SECURITY.MD V0.0.9 BLOCK -->
 
 ## Security
 
-Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet), [Xamarin](https://github.com/xamarin), and [our GitHub organizations](https://opensource.microsoft.com/).
+Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/Microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet), [Xamarin](https://github.com/xamarin) and [PowerShell](https://github.com/PowerShell).
 
-If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://aka.ms/opensource/security/definition), please report it to us as described below.
+If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://aka.ms/security.md/definition), please report it to us as described below.
 
 ## Reporting Security Issues
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://aka.ms/opensource/security/create-report).
+Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://aka.ms/security.md/msrc/create-report).
 
-If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://aka.ms/opensource/security/pgpkey).
+If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://aka.ms/security.md/msrc/pgp).
 
-You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://aka.ms/opensource/security/msrc). 
+You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc). 
 
 Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
 
@@ -28,7 +28,7 @@ Please include the requested information listed below (as much as you can provid
 
 This information will help us triage your report more quickly.
 
-If you are reporting for a bug bounty, more complete reports can contribute to a higher bounty award. Please visit our [Microsoft Bug Bounty Program](https://aka.ms/opensource/security/bounty) page for more details about our active programs.
+If you are reporting for a bug bounty, more complete reports can contribute to a higher bounty award. Please visit our [Microsoft Bug Bounty Program](https://aka.ms/security.md/msrc/bounty) page for more details about our active programs.
 
 ## Preferred Languages
 
@@ -36,6 +36,6 @@ We prefer all communications to be in English.
 
 ## Policy
 
-Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://aka.ms/opensource/security/cvd).
+Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://aka.ms/security.md/cvd).
 
 <!-- END MICROSOFT SECURITY.MD BLOCK -->


### PR DESCRIPTION
Updates the readme, code of conduct and security policy per OSPO request.

I didn't have anything setup to auto renumber the links so I just...carefully made a new link to keep the numbering in order.